### PR TITLE
Add u8 to string length options + clippy/fmt

### DIFF
--- a/benches/benchmarks/de_simple_struct.rs
+++ b/benches/benchmarks/de_simple_struct.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, Criterion, BenchmarkId};
+use criterion::{black_box, criterion_group, BenchmarkId, Criterion};
 use serde::Deserialize;
 
 #[derive(Clone, Debug, Deserialize)]
@@ -33,12 +33,12 @@ fn bench_de_simple_struct(c: &mut Criterion) {
 
     group.bench_function(
         BenchmarkId::new("de_simple_struct_json", "SimpleStruct"),
-        |b| b.iter(|| serde_json::from_slice::<'_, SimpleStruct>(black_box(json)).unwrap())
+        |b| b.iter(|| serde_json::from_slice::<'_, SimpleStruct>(black_box(json)).unwrap()),
     );
 
     group.bench_function(
         BenchmarkId::new("de_simple_struct_ub_json", "SimpleStruct"),
-        |b| b.iter(|| serde_ub_json::from_bytes::<'_, SimpleStruct>(black_box(&ub_json)).unwrap())
+        |b| b.iter(|| serde_ub_json::from_bytes::<'_, SimpleStruct>(black_box(&ub_json)).unwrap()),
     );
 
     group.finish();

--- a/benches/benchmarks/de_vec_of_integers.rs
+++ b/benches/benchmarks/de_vec_of_integers.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, Criterion, BenchmarkId};
+use criterion::{black_box, criterion_group, BenchmarkId, Criterion};
 use serde::Deserialize;
 
 fn bench_de_vec_of_i8(c: &mut Criterion) {
@@ -21,15 +21,13 @@ fn bench_de_vec_of_i8(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("de_vec_of_i8");
 
-    group.bench_function(
-        BenchmarkId::new("de_vec_of_i8_json", "Vec<i8>"),
-        |b| b.iter(|| serde_json::from_slice::<'_, Vec<i8>>(black_box(&json)).unwrap())
-    );
+    group.bench_function(BenchmarkId::new("de_vec_of_i8_json", "Vec<i8>"), |b| {
+        b.iter(|| serde_json::from_slice::<'_, Vec<i8>>(black_box(&json)).unwrap())
+    });
 
-    group.bench_function(
-        BenchmarkId::new("de_vec_of_i8_ub_json", "Vec<i8>"),
-        |b| b.iter(|| serde_ub_json::from_bytes::<'_, Vec<i8>>(black_box(&ub_json)).unwrap())
-    );
+    group.bench_function(BenchmarkId::new("de_vec_of_i8_ub_json", "Vec<i8>"), |b| {
+        b.iter(|| serde_ub_json::from_bytes::<'_, Vec<i8>>(black_box(&ub_json)).unwrap())
+    });
 
     group.finish();
 }
@@ -54,15 +52,13 @@ fn bench_de_vec_of_i16(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("de_vec_of_i16");
 
-    group.bench_function(
-        BenchmarkId::new("de_vec_of_i16_json", "Vec<i16>"),
-        |b| b.iter(|| serde_json::from_slice::<'_, Vec<i16>>(black_box(&json)).unwrap())
-    );
+    group.bench_function(BenchmarkId::new("de_vec_of_i16_json", "Vec<i16>"), |b| {
+        b.iter(|| serde_json::from_slice::<'_, Vec<i16>>(black_box(&json)).unwrap())
+    });
 
-    group.bench_function(
-        BenchmarkId::new("de_vec_of_i16_ub_json", "Vec<i16>"),
-        |b| b.iter(|| serde_ub_json::from_bytes::<'_, Vec<i16>>(black_box(&ub_json)).unwrap())
-    );
+    group.bench_function(BenchmarkId::new("de_vec_of_i16_ub_json", "Vec<i16>"), |b| {
+        b.iter(|| serde_ub_json::from_bytes::<'_, Vec<i16>>(black_box(&ub_json)).unwrap())
+    });
 
     group.finish();
 }

--- a/benches/benchmarks/mod.rs
+++ b/benches/benchmarks/mod.rs
@@ -1,4 +1,4 @@
-pub mod ser_simple_struct;
-pub mod ser_vec_of_integers;
 pub mod de_simple_struct;
 pub mod de_vec_of_integers;
+pub mod ser_simple_struct;
+pub mod ser_vec_of_integers;

--- a/benches/benchmarks/ser_simple_struct.rs
+++ b/benches/benchmarks/ser_simple_struct.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, Criterion, BenchmarkId};
+use criterion::{black_box, criterion_group, BenchmarkId, Criterion};
 use serde::Serialize;
 
 #[derive(Clone, Debug, Serialize)]
@@ -17,12 +17,12 @@ fn bench_ser_simple_struct(c: &mut Criterion) {
 
     group.bench_function(
         BenchmarkId::new("ser_simple_struct_json", "SimpleStruct"),
-        |b| b.iter(|| serde_json::to_vec(black_box(&value)))
+        |b| b.iter(|| serde_json::to_vec(black_box(&value))),
     );
 
     group.bench_function(
         BenchmarkId::new("ser_simple_struct_ub_json", "SimpleStruct"),
-        |b| b.iter(|| serde_ub_json::to_bytes(black_box(&value)))
+        |b| b.iter(|| serde_ub_json::to_bytes(black_box(&value))),
     );
 
     group.finish();

--- a/benches/benchmarks/ser_vec_of_integers.rs
+++ b/benches/benchmarks/ser_vec_of_integers.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, Criterion, BenchmarkId};
+use criterion::{black_box, criterion_group, BenchmarkId, Criterion};
 use serde::Serialize;
 
 fn bench_ser_vec_of_i8(c: &mut Criterion) {
@@ -9,15 +9,13 @@ fn bench_ser_vec_of_i8(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("ser_vec_of_i8");
 
-    group.bench_function(
-        BenchmarkId::new("ser_vec_of_i8_json", "Vec<i8>"),
-        |b| b.iter(|| serde_json::to_vec(black_box(&value)))
-    );
+    group.bench_function(BenchmarkId::new("ser_vec_of_i8_json", "Vec<i8>"), |b| {
+        b.iter(|| serde_json::to_vec(black_box(&value)))
+    });
 
-    group.bench_function(
-        BenchmarkId::new("ser_vec_of_i8_ub_json", "Vec<i8>"),
-        |b| b.iter(|| serde_ub_json::to_bytes(black_box(&value)))
-    );
+    group.bench_function(BenchmarkId::new("ser_vec_of_i8_ub_json", "Vec<i8>"), |b| {
+        b.iter(|| serde_ub_json::to_bytes(black_box(&value)))
+    });
 
     group.finish();
 }
@@ -30,14 +28,13 @@ fn bench_ser_vec_of_i16(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("ser_simple_struct");
 
-    group.bench_function(
-        BenchmarkId::new("ser_vec_of_i16_json", "Vec<i16>"),
-        |b| b.iter(|| serde_json::to_vec(black_box(&value)))
-    );
+    group.bench_function(BenchmarkId::new("ser_vec_of_i16_json", "Vec<i16>"), |b| {
+        b.iter(|| serde_json::to_vec(black_box(&value)))
+    });
 
     group.bench_function(
         BenchmarkId::new("ser_vec_of_i16_ub_json", "Vec<i16>"),
-        |b| b.iter(|| serde_ub_json::to_bytes(black_box(&value)))
+        |b| b.iter(|| serde_ub_json::to_bytes(black_box(&value))),
     );
 
     group.finish();

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
-use std::fmt::{Debug, Display, Formatter};
 use crate::value::Marker;
+use std::fmt::{Debug, Display, Formatter};
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -53,8 +53,8 @@ impl Display for Error {
 
 impl serde::ser::Error for Error {
     fn custom<T>(msg: T) -> Self
-        where
-            T: Display,
+    where
+        T: Display,
     {
         let s = format!("{}", msg);
         Self::Custom(s)
@@ -63,8 +63,8 @@ impl serde::ser::Error for Error {
 
 impl serde::de::Error for Error {
     fn custom<T>(msg: T) -> Self
-        where
-            T: Display,
+    where
+        T: Display,
     {
         let s = format!("{}", msg);
         Self::Custom(s)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
-pub use error::{Error, Result};
-pub use value::Value;
-pub use ser::to_bytes;
 pub use de::from_bytes;
+pub use error::{Error, Result};
+pub use ser::to_bytes;
+pub use value::Value;
 
 mod de;
 mod error;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -6,12 +6,12 @@ use serde::ser::{
 };
 use serde::Serialize;
 
-use crate::{Error, Result};
 use crate::value::Marker;
+use crate::{Error, Result};
 
 pub fn to_bytes<T>(value: &T) -> Result<Vec<u8>>
-    where
-        T: Serialize,
+where
+    T: Serialize,
 {
     let mut bytes = Vec::new();
     let policy = SimpleFormatter::new(&mut bytes);
@@ -25,8 +25,8 @@ pub struct Serializer<F> {
 }
 
 impl<F> Serializer<F>
-    where
-        F: Formatter,
+where
+    F: Formatter,
 {
     pub fn new(formatter: F) -> Self {
         Self { formatter }
@@ -34,8 +34,8 @@ impl<F> Serializer<F>
 }
 
 impl<'a, F> serde::ser::Serializer for &'a mut Serializer<F>
-    where
-        F: Formatter,
+where
+    F: Formatter,
 {
     type Ok = ();
     type Error = Error;
@@ -131,7 +131,7 @@ impl<'a, F> serde::ser::Serializer for &'a mut Serializer<F>
         let len = bytes.len();
 
         self.formatter.len(len)?;
-        self.formatter.raw(&bytes)?;
+        self.formatter.raw(bytes)?;
 
         Ok(())
     }
@@ -168,7 +168,7 @@ impl<'a, F> serde::ser::Serializer for &'a mut Serializer<F>
         let len = bytes.len();
 
         self.formatter.len(len)?;
-        self.formatter.raw(&bytes)?;
+        self.formatter.raw(bytes)?;
 
         Ok(())
     }
@@ -199,9 +199,9 @@ impl<'a, F> serde::ser::Serializer for &'a mut Serializer<F>
         Ok(())
     }
 
-    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok>
-        where
-            T: Serialize,
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok>
+    where
+        T: Serialize + ?Sized,
     {
         value.serialize(self)?;
         Ok(())
@@ -229,23 +229,23 @@ impl<'a, F> serde::ser::Serializer for &'a mut Serializer<F>
         self.serialize_str(variant)
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, value: &T) -> Result<Self::Ok>
-        where
-            T: Serialize,
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<Self::Ok>
+    where
+        T: Serialize + ?Sized,
     {
         value.serialize(self)?;
         Ok(())
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
         variant: &'static str,
         value: &T,
     ) -> Result<Self::Ok>
-        where
-            T: Serialize,
+    where
+        T: Serialize + ?Sized,
     {
         if self.formatter.get_mode().is_key() {
             return Err(Error::InvalidKey);
@@ -367,15 +367,15 @@ pub struct ArraySerializer<'a, F> {
 }
 
 impl<'a, F> SerializeSeq for ArraySerializer<'a, F>
-    where
-        F: Formatter,
+where
+    F: Formatter,
 {
     type Ok = ();
     type Error = Error;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<Self::Ok>
-        where
-            T: Serialize,
+    fn serialize_element<T>(&mut self, value: &T) -> Result<Self::Ok>
+    where
+        T: Serialize + ?Sized,
     {
         value.serialize(&mut *self.ser)?;
         Ok(())
@@ -390,15 +390,15 @@ impl<'a, F> SerializeSeq for ArraySerializer<'a, F>
 }
 
 impl<'a, F> SerializeTuple for ArraySerializer<'a, F>
-    where
-        F: Formatter,
+where
+    F: Formatter,
 {
     type Ok = ();
     type Error = Error;
 
-    fn serialize_element<T: ?Sized>(&mut self, _value: &T) -> Result<Self::Ok>
-        where
-            T: Serialize,
+    fn serialize_element<T>(&mut self, _value: &T) -> Result<Self::Ok>
+    where
+        T: Serialize + ?Sized,
     {
         Ok(())
     }
@@ -409,15 +409,15 @@ impl<'a, F> SerializeTuple for ArraySerializer<'a, F>
 }
 
 impl<'a, F> SerializeTupleStruct for ArraySerializer<'a, F>
-    where
-        F: Formatter,
+where
+    F: Formatter,
 {
     type Ok = ();
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, _value: &T) -> Result<Self::Ok>
-        where
-            T: Serialize,
+    fn serialize_field<T>(&mut self, _value: &T) -> Result<Self::Ok>
+    where
+        T: Serialize + ?Sized,
     {
         Ok(())
     }
@@ -433,24 +433,24 @@ pub struct ObjectSerializer<'a, F> {
 }
 
 impl<'a, F> SerializeMap for ObjectSerializer<'a, F>
-    where
-        F: Formatter,
+where
+    F: Formatter,
 {
     type Ok = ();
     type Error = Error;
 
-    fn serialize_key<T: ?Sized>(&mut self, key: &T) -> std::result::Result<(), Self::Error>
-        where
-            T: Serialize,
+    fn serialize_key<T>(&mut self, key: &T) -> std::result::Result<(), Self::Error>
+    where
+        T: Serialize + ?Sized,
     {
         self.ser.formatter.set_mode(FormatterMode::Key);
         key.serialize(&mut *self.ser)?;
         Ok(())
     }
 
-    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> std::result::Result<(), Self::Error>
-        where
-            T: Serialize,
+    fn serialize_value<T>(&mut self, value: &T) -> std::result::Result<(), Self::Error>
+    where
+        T: Serialize + ?Sized,
     {
         self.ser.formatter.set_mode(FormatterMode::Value);
         value.serialize(&mut *self.ser)?;
@@ -466,15 +466,15 @@ impl<'a, F> SerializeMap for ObjectSerializer<'a, F>
 }
 
 impl<'a, F> SerializeStruct for ObjectSerializer<'a, F>
-    where
-        F: Formatter,
+where
+    F: Formatter,
 {
     type Ok = ();
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<Self::Ok>
-        where
-            T: Serialize,
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<Self::Ok>
+    where
+        T: Serialize + ?Sized,
     {
         self.serialize_key(key)?;
         self.serialize_value(value)?;
@@ -495,15 +495,15 @@ pub struct VariantSerializer<'a, F> {
 }
 
 impl<'a, F> SerializeTupleVariant for VariantSerializer<'a, F>
-    where
-        F: Formatter,
+where
+    F: Formatter,
 {
     type Ok = ();
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<Self::Ok>
-        where
-            T: Serialize,
+    fn serialize_field<T>(&mut self, value: &T) -> Result<Self::Ok>
+    where
+        T: Serialize + ?Sized,
     {
         value.serialize(&mut *self.ser)
     }
@@ -514,15 +514,15 @@ impl<'a, F> SerializeTupleVariant for VariantSerializer<'a, F>
 }
 
 impl<'a, F> SerializeStructVariant for VariantSerializer<'a, F>
-    where
-        F: Formatter,
+where
+    F: Formatter,
 {
     type Ok = ();
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<Self::Ok>
-        where
-            T: Serialize,
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<Self::Ok>
+    where
+        T: Serialize + ?Sized,
     {
         self.ser.formatter.set_mode(FormatterMode::Key);
         key.serialize(&mut *self.ser)?;
@@ -569,8 +569,8 @@ pub struct SimpleFormatter<'a, W> {
 }
 
 impl<'a, W> SimpleFormatter<'a, W>
-    where
-        W: Write,
+where
+    W: Write,
 {
     pub fn new(writer: &'a mut W) -> SimpleFormatter<'a, W> {
         SimpleFormatter {
@@ -581,8 +581,8 @@ impl<'a, W> SimpleFormatter<'a, W>
 }
 
 impl<'a, W> Formatter for SimpleFormatter<'a, W>
-    where
-        W: Write,
+where
+    W: Write,
 {
     fn set_mode(&mut self, mode: FormatterMode) {
         self.mode = mode;

--- a/src/value.rs
+++ b/src/value.rs
@@ -44,15 +44,15 @@ pub enum Marker {
     OfType = b'$',
 }
 
-impl Into<char> for Marker {
-    fn into(self) -> char {
-        self as u8 as char
+impl From<Marker> for char {
+    fn from(val: Marker) -> Self {
+        val as u8 as char
     }
 }
 
-impl Into<&[u8]> for Marker {
-    fn into(self) -> &'static [u8] {
-        match self {
+impl From<Marker> for &[u8] {
+    fn from(val: Marker) -> Self {
+        match val {
             Marker::Null => b"Z",
             Marker::NoOp => b"N",
             Marker::True => b"T",


### PR DESCRIPTION
The UBJSON spec doesn't outright say that u8 could be used for the length, but in some files that I have tested and examined, as well as on the [wikipedia page](https://en.wikipedia.org/wiki/UBJSON#length_(optional)) (very reliable sources I know...) there are examples of a string having a u8 for the marker of its length.